### PR TITLE
ffmpeg is missing for transcoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN /supysonic/build/build.sh
 
 FROM alpine:${ALPINE_VERSION}
 COPY --from=0 /supysonic/pkg /
-RUN apk add expat libffi libjpeg-turbo sqlite-libs && \
+RUN apk add expat libffi libjpeg-turbo sqlite-libs ffmpeg && \
   chown supysonic:users /var/lib/supysonic /var/log/supysonic && \
   rm -rf /root/.ash_history /root/.cache /var/cache/apk/*
 ENV \


### PR DESCRIPTION
Package `ffmpeg` was missing but required by `supysonic` to transcode music files to lower bitrates or to MP3.

`ffmpeg` is used as a general transcoder, which can be seen in the example configuration.
https://github.com/spl0k/supysonic/blob/8d6821df991a87df317b4be92bcb8042b61246a4/config.sample#L73
